### PR TITLE
adding UnregisterSubscriber MEthod to TopicService

### DIFF
--- a/src/ServiceFabricPubSub/PubSubDotnetSDK/ITopicService.cs
+++ b/src/ServiceFabricPubSub/PubSubDotnetSDK/ITopicService.cs
@@ -23,6 +23,13 @@ namespace PubSubDotnetSDK
         /// <returns></returns>
         Task RegisterSubscriber(string subscriberId);
 
+        /// <summary>
+        /// Remove a subscriber target from a topic. 
+        /// After calling this method, the topic service will not more duplicate message for the subscriber. 
+        /// </summary>
+        /// <param name="subscriberId"></param>
+        /// <returns>true if subscriberId is known end removed, false otherwise</returns>
+        Task<bool> UnregisterSubscriber(string subscriberId);
 
 
         /// <summary>


### PR DESCRIPTION
Topic now support unregisterung a subscriber.
The UnregisterMethod should be called by the admin service before removing a SubcriberService instance.